### PR TITLE
docs: add uninstallation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,30 @@ connex --debug
 connex --no-scan
 ```
 
+## Uninstallation
+
+Since connex is installed manually (not via a package manager), `apt remove` or similar commands won't work. Instead, use the included uninstall script:
+
+```bash
+# Clone the repository if you don't have it anymore
+git clone https://github.com/lluciocc/connex.git
+cd connex
+chmod +x ./uninstall.sh
+./uninstall.sh
+```
+
+Or download and run it directly:
+```bash
+curl -sSL https://raw.githubusercontent.com/Lluciocc/connex/master/uninstall.sh | bash
+```
+
+The script will:
+- Stop any running connex processes
+- Remove the executable from `/usr/local/bin/`
+- Remove application files from `/usr/local/lib/connex/`
+- Remove desktop entries, icons, and autostart config
+- Optionally remove your user configuration (`~/.config/connex/`)
+
 ## Configuration
 
 connex stores its configuration and logs in:


### PR DESCRIPTION
## Problem

The project includes a well-written `uninstall.sh` script, but the **README never mentions it**. Users trying to remove connex (like in #9) have no way to discover it — `apt remove` doesn't work because connex was installed manually via `install.sh`, not through a package manager.

## Fix

Added an **"Uninstallation"** section to the README that explains:

1. **Why `apt remove` doesn't work** — connex is installed manually, not via apt
2. **How to run `uninstall.sh`** — both via clone and via `curl` one-liner
3. **What the script does** — stops processes, removes files from `/usr/local/`, removes desktop entries/icons/autostart, and optionally removes user config

### The uninstall script already exists
```
uninstall.sh  ← already in the repo, well-written with 4 steps
```

### What was missing
The README had installation instructions but **zero mention** of how to uninstall. This PR simply documents the existing uninstall script.

## Related Issues

Fixes #9